### PR TITLE
Default to French locale with English switch

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,16 +13,13 @@ export default defineConfig({
   image: {
     domains: ["images.unsplash.com"],
   },
-  // i18n: {
-  //   defaultLocale: "fr",
-  //   locales: ["en", "fr"],
-  //   fallback: {
-  //     fr: "en",
-  //   },
-  //   routing: {
-  //     prefixDefaultLocale: false,
-  //   },
-  // },
+  i18n: {
+    defaultLocale: "fr",
+    locales: ["en", "fr"],
+    routing: {
+      prefixDefaultLocale: true,
+    },
+  },
   prefetch: true,
   integrations: [
     sitemap({
@@ -41,18 +38,6 @@ export default defineConfig({
       // If only a Starlight i18n configuration is provided, an equivalent Astro i18n configuration is generated/used.
       // If only an Astro i18n configuration is provided, the Starlight i18n configuration is updated to match it.
       // If both an Astro and Starlight i18n configurations are provided, an error is thrown.
-      locales: {
-        root: {
-          label: "English",
-          lang: "en",
-        },
-        de: { label: "Deutsch", lang: "de" },
-        es: { label: "Español", lang: "es" },
-        fa: { label: "Persian", lang: "fa", dir: "rtl" },
-        fr: { label: "Français", lang: "fr" },
-        ja: { label: "日本語", lang: "ja" },
-        "zh-cn": { label: "简体中文", lang: "zh-CN" },
-      },
       // https://starlight.astro.build/guides/sidebar/
       sidebar: [
         {

--- a/src/components/sections/navbar&footer/Navbar.astro
+++ b/src/components/sections/navbar&footer/Navbar.astro
@@ -9,7 +9,7 @@ import LanguagePicker from "@components/ui/LanguagePicker.astro";
 
 // Select the correct translation based on the page's lang prop:
 const strings = Astro.currentLocale === "fr" ? frStrings : enStrings;
-const homeUrl = Astro.currentLocale === "fr" ? "/fr" : "/";
+const homeUrl = Astro.currentLocale === "fr" ? "/fr" : "/en";
 ---
 
 <!-- Main header component -->

--- a/src/components/sections/navbar&footer/NavbarMegaMenu.astro
+++ b/src/components/sections/navbar&footer/NavbarMegaMenu.astro
@@ -9,7 +9,7 @@ import LanguagePicker from "@components/ui/LanguagePicker.astro";
 import Authentication from "@components/sections/misc/Authentication.astro";
 
 const strings = Astro.currentLocale === "fr" ? frStrings : enStrings;
-const homeUrl = Astro.currentLocale === "fr" ? "/fr" : "/";
+const homeUrl = Astro.currentLocale === "fr" ? "/fr" : "/en";
 ---
 
 <header

--- a/src/components/ui/LanguagePicker.astro
+++ b/src/components/ui/LanguagePicker.astro
@@ -33,7 +33,7 @@ import Icon from "./icons/Icon.astro";
       Object.entries(languages).map(([lang, label]) => (
         <a
           class="flex items-center gap-x-3.5 rounded-lg px-3 py-2 text-sm text-neutral-800 hover:bg-neutral-100 focus:bg-neutral-100 focus:outline-hidden dark:text-neutral-400 dark:hover:bg-neutral-700 dark:hover:text-neutral-300 dark:focus:bg-neutral-700"
-          href={`/${lang === "en" ? "" : lang}`}
+          href={`/${lang}`}
         >
           {label}
         </a>
@@ -69,16 +69,11 @@ import Icon from "./icons/Icon.astro";
           .filter((part) => part && !languages.includes(part as TLanguage))
           .join("/");
 
-        let newPath = "";
-        if (lang && lang !== "en") {
-          newPath = `/${lang}/${currentPath}`;
-        } else {
-          newPath = `/${currentPath}`;
+        let newPath = `/${lang}`;
+        if (currentPath) {
+          newPath += `/${currentPath}`;
         }
-
         newPath = newPath.replace(/\/+/g, "/");
-        if (newPath === "") newPath = "/";
-        
         window.location.href = `${url.origin}${newPath}${url.search}`;
       });
     });

--- a/src/pages/en/contact.astro
+++ b/src/pages/en/contact.astro
@@ -17,8 +17,8 @@ const ogTitle = "Contact Us | Noscentia";
   structuredData={{
     "@context": "https://schema.org",
     "@type": "WebPage",
-    "@id": "https://noscentia.com/contact",
-    url: "https://noscentia.com/contact",
+    "@id": "https://noscentia.com/en/contact",
+    url: "https://noscentia.com/en/contact",
     name: "Contact Us | Noscentia",
     description:
       "Interested in placing an order or have questions about our offerings? Contact us — Noscentia is here to help craft the perfect solution for your needs.",

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,0 +1,66 @@
+---
+// Import the necessary components
+import MainLayout from "@/layouts/MainLayout.astro";
+import HeroSection from "@components/sections/landing/HeroSection.astro";
+import HeroSectionAlt from "@components/sections/landing/HeroSectionAlt.astro";
+import ClientsSection from "@components/sections/landing/ClientsSection.astro";
+import FeaturesGeneral from "@components/sections/features/FeaturesGeneral.astro";
+import FeaturesNavs from "@components/sections/features/FeaturesNavs.astro";
+import TestimonialsSection from "@components/sections/testimonials/TestimonialsSection.astro";
+import PricingSection from "@components/sections/pricing/PricingSection.astro";
+import FAQ from "@components/sections/misc/FAQ.astro";
+
+import heroImage from "@images/NavetteParallelZoomOut.png";
+import faqs from "@data/faqs.json";
+import features from "@data/features.json";
+
+import featureImage from "@images/FloatingNavettesFull.png";
+import construction from "@images/construction-image.avif";
+import tools from "@images/automated-tools.avif";
+import dashboard from "@images/dashboard-image.avif";
+import { partnersData } from "@/data_files/constants";
+
+const avatarSrcs: Array<string> = [
+  "https://images.unsplash.com/photo-1568602471122-7832951cc4c5?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=facearea&facepad=2&w=300&h=300&q=80",
+  "https://images.unsplash.com/photo-1531927557220-a9e23c1e4794?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=facearea&facepad=2&w=300&h=300&q=80",
+  "https://images.unsplash.com/photo-1541101767792-f9b2b1c4f127?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&&auto=format&fit=facearea&facepad=3&w=300&h=300&q=80",
+  "https://images.unsplash.com/photo-1492562080023-ab3db95bfbce?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=facearea&facepad=2&w=300&h=300&q=80",
+];
+---
+
+<MainLayout>
+  
+
+  <HeroSection
+    title=`Engineered for weaving by <span
+        class="text-blue-600 dark:text-blue-600"> Noscentia</span>`
+    subTitle="Premium weaving shuttles, precision-built for smooth performance."
+    primaryBtn="Discover our products"
+      primaryBtnURL="/en/products"
+      secondaryBtn="Contact Sales Team"
+      secondaryBtnURL="/en/contact"
+    
+    
+    
+    
+    src={heroImage}
+    alt="Navette"
+  />
+
+  
+
+  <FeaturesGeneral
+    title="Meeting Industry Demands"
+    subTitle="At Noscentia, we understand the unique demands of modern weaving. Our premium, precision-built 3D-printed shuttles are designed to enhance efficiency and elevate the weaving experience."
+    src={featureImage}
+    alt="Navette"
+    features={features}
+  />
+
+  
+
+  
+    
+
+  
+</MainLayout>

--- a/src/pages/en/products/[id].astro
+++ b/src/pages/en/products/[id].astro
@@ -20,7 +20,7 @@ export async function getStaticPaths() {
     id.startsWith("en/")
   );
   return productEntries.map((product) => {
-    const idWithoutLang = product.id.replace(/^en\//, ""); // Remove the "fr/" prefix
+    const idWithoutLang = product.id.replace(/^en\//, ""); // Remove the "en/" prefix
     return {
       params: { id: idWithoutLang},
       props: { product },
@@ -32,25 +32,25 @@ const { product } = Astro.props;
 
 const pageTitle: string = `${product.data.title} | ${SITE.title}`;
 const metaDescription = product.data.description;
-const ogTitle = `${product.data.title} | Outils Matériels | ScrewFast`;
+const ogTitle = `${product.data.title} | Noscentia Products`;
 ---
 
 <MainLayout
   title={pageTitle}
-  lang="fr"
+  lang="en"
   customDescription={metaDescription}
   customOgTitle={ogTitle}
   structuredData={{
     "@context": "https://schema.org",
     "@type": "Product",
-    "@id": `https://noscentia.com/fr/products/${product.data.title.toLowerCase().replace(/\s+/g, "-")}`,
+    "@id": `https://noscentia.com/en/products/${product.data.title.toLowerCase().replace(/\s+/g, "-")}`,
     name: product.data.title,
     description: product.data.description,
     brand: {
       "@type": "Brand",
       name: "Noscentia",
     },
-    inLanguage: "fr",
+    inLanguage: "en",
   }}
 >
   <div id="overlay" class="fixed inset-0 bg-neutral-200 dark:bg-neutral-800">

--- a/src/pages/en/products/index.astro
+++ b/src/pages/en/products/index.astro
@@ -74,8 +74,8 @@ const ogTitle = "Hardware Tools | ScrewFast";
   structuredData={{
     "@context": "https://schema.org",
     "@type": "WebPage",
-    "@id": "https://noscentia.com/products",
-    url: "https://noscentia.com/products",
+    "@id": "https://noscentia.com/en/products",
+    url: "https://noscentia.com/en/products",
     name: "Weaving Shuttles | Noscentia",
     description:
       "Explore the durability and precision of Noscentia weaving tools, designed for both professionals and enthusiasts.",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,66 +1,12 @@
 ---
-// Import the necessary components
-import MainLayout from "@/layouts/MainLayout.astro";
-import HeroSection from "@components/sections/landing/HeroSection.astro";
-import HeroSectionAlt from "@components/sections/landing/HeroSectionAlt.astro";
-import ClientsSection from "@components/sections/landing/ClientsSection.astro";
-import FeaturesGeneral from "@components/sections/features/FeaturesGeneral.astro";
-import FeaturesNavs from "@components/sections/features/FeaturesNavs.astro";
-import TestimonialsSection from "@components/sections/testimonials/TestimonialsSection.astro";
-import PricingSection from "@components/sections/pricing/PricingSection.astro";
-import FAQ from "@components/sections/misc/FAQ.astro";
+export const prerender = true;
 
-import heroImage from "@images/NavetteParallelZoomOut.png";
-import faqs from "@data/faqs.json";
-import features from "@data/features.json";
-
-import featureImage from "@images/FloatingNavettesFull.png";
-import construction from "@images/construction-image.avif";
-import tools from "@images/automated-tools.avif";
-import dashboard from "@images/dashboard-image.avif";
-import { partnersData } from "@/data_files/constants";
-
-const avatarSrcs: Array<string> = [
-  "https://images.unsplash.com/photo-1568602471122-7832951cc4c5?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=facearea&facepad=2&w=300&h=300&q=80",
-  "https://images.unsplash.com/photo-1531927557220-a9e23c1e4794?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=facearea&facepad=2&w=300&h=300&q=80",
-  "https://images.unsplash.com/photo-1541101767792-f9b2b1c4f127?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&&auto=format&fit=facearea&facepad=3&w=300&h=300&q=80",
-  "https://images.unsplash.com/photo-1492562080023-ab3db95bfbce?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=facearea&facepad=2&w=300&h=300&q=80",
-];
+export async function GET() {
+  return new Response(null, {
+    status: 301,
+    headers: {
+      Location: '/fr',
+    },
+  });
+}
 ---
-
-<MainLayout>
-  
-
-  <HeroSection
-    title=`Engineered for weaving by <span
-        class="text-blue-600 dark:text-blue-600"> Noscentia</span>`
-    subTitle="Premium weaving shuttles, precision-built for smooth performance."
-    primaryBtn="Discover our products"
-    primaryBtnURL="/products"
-    secondaryBtn="Contact Sales Team"
-    secondaryBtnURL="/contact"
-    
-    
-    
-    
-    src={heroImage}
-    alt="Navette"
-  />
-
-  
-
-  <FeaturesGeneral
-    title="Meeting Industry Demands"
-    subTitle="At Noscentia, we understand the unique demands of modern weaving. Our premium, precision-built 3D-printed shuttles are designed to enhance efficiency and elevate the weaving experience."
-    src={featureImage}
-    alt="Navette"
-    features={features}
-  />
-
-  
-
-  
-    
-
-  
-</MainLayout>

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,25 +1,25 @@
 // An array of links for navigation bar
 const navBarLinks = [
-  { name: "Home", url: "/" },
-  { name: "Products", url: "/products" },
-  { name: "Contact", url: "/contact" },
-  
+  { name: "Home", url: "/en" },
+  { name: "Products", url: "/en/products" },
+  { name: "Contact", url: "/en/contact" },
+
 ];
 // An array of links for footer
 const footerLinks = [
   {
     section: "Ecosystem",
     links: [
-      { name: "Documentation", url: "/welcome-to-docs/" },
-      { name: "Tools & Equipment", url: "/products" },
-      { name: "Construction Services", url: "/services" },
+      { name: "Documentation", url: "/en/welcome-to-docs/" },
+      { name: "Tools & Equipment", url: "/en/products" },
+      { name: "Construction Services", url: "/en/services" },
     ],
   },
   {
     section: "Company",
     links: [
       { name: "About us", url: "#" },
-      { name: "Blog", url: "/blog" },
+      { name: "Blog", url: "/en/blog" },
       { name: "Careers", url: "#" },
       { name: "Customers", url: "#" },
     ],

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,7 @@
 {
+  "redirects": [
+    { "source": "/", "destination": "/fr", "permanent": true }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- redirect root domain to `/fr`
- enable i18n and navigation for `/en` English pages
- update language picker and navigation links for language switching

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689544fbbc548329bf7c46bb7c38002e